### PR TITLE
Add support for UID's wrapped in curly brackets

### DIFF
--- a/ss_data.ps1
+++ b/ss_data.ps1
@@ -10,7 +10,7 @@ switch ($qtype) {
         $qparam = $args[1]
         $qid = $args[2]
         
-        $sp = Get-StoragePool -UniqueId "$qid"
+        $sp = Get-StoragePool -UniqueId "{$qid}"
         if (-not $sp) {
             echo "Object not found!"
             exit

--- a/ss_data.ps1
+++ b/ss_data.ps1
@@ -12,6 +12,9 @@ switch ($qtype) {
         
         $sp = Get-StoragePool -UniqueId "{$qid}"
         if (-not $sp) {
+            $sp = Get-StoragePool -UniqueId "$qid"
+        }
+        if (-not $sp) {
             echo "Object not found!"
             exit
         }

--- a/ss_discovery.ps1
+++ b/ss_discovery.ps1
@@ -7,7 +7,7 @@ switch ($dtype) {
 
         echo "{`n `"data`":[`n"
         foreach ($sp in $StoragePools) {
-            $line = "{ `n`"{#POOL}`":`"" + $sp.FriendlyName + "`",`n`"{#PDN}`":`"" + $sp.UniqueId + "`",`n`"{#PH}`":`"0`"`n}`n,"
+            $line = "{ `n`"{#POOL}`":`"" + $sp.FriendlyName + "`",`n`"{#PDN}`":`"" + $($sp.UniqueId -replace '[{}]') + "`",`n`"{#PH}`":`"0`"`n}`n,"
             echo $line
         }
 

--- a/userparameters.conf
+++ b/userparameters.conf
@@ -1,3 +1,3 @@
 UserParameter=storagespaces.discovery[*],PowerShell.exe -ExecutionPolicy UnRestricted -File C:\zabbix\scripts\ss_discovery.ps1 $1
-UserParameter=storagespaces.data[*],PowerShell.exe -ExecutionPolicy UnRestricted -File C:\zabbix\scripts\ss_data.ps1 $1 $2 "$3
+UserParameter=storagespaces.data[*],PowerShell.exe -ExecutionPolicy UnRestricted -File C:\zabbix\scripts\ss_data.ps1 $1 $2 $3
 


### PR DESCRIPTION
Zabbix will throw an error if you try to pass a UID with the characters { or }. Added some logic to handle this.